### PR TITLE
Fix #2 Make JIRA Software edition available.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -14,10 +14,18 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
   && apt-get purge -y --auto-remove curl
 
 # grab the jira dependencies
-RUN apt-get update && apt-get install -y \
-    openjdk-7-jre-headless \
+RUN apt-get update && apt-get install -y ca-certificates \
+  && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
+  && echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > /etc/apt/sources.list.d/webupd8team-java.list \
+  && echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list.d/webupd8team-java.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 \
+  && apt-get update && apt-get install -y \
+    oracle-java8-installer \
+    oracle-java8-set-default \
     libtcnative-1 \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/cache/oracle-jdk8-installer \
+  && rm -f /ect/apt/sources.list.d/webupd8team-java.list
 
 ENV JIRA_VERSION {{.Version}}
 

--- a/update.go
+++ b/update.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	archiveUrl = `https://my.atlassian.com/download/feeds/archived/jira.json`
-	currentUrl = `https://my.atlassian.com/download/feeds/current/jira.json`
-	eapUrl     = `https://my.atlassian.com/download/feeds/eap/jira.json`
+	archiveUrl = `https://my.atlassian.com/download/feeds/archived/jira-software.json`
+	currentUrl = `https://my.atlassian.com/download/feeds/current/jira-software.json`
+	eapUrl     = `https://my.atlassian.com/download/feeds/eap/jira-software.json`
 )
 
 var tmpl = template.Must(template.ParseFiles("Dockerfile.tmpl"))
@@ -128,10 +128,7 @@ func fetchLatestTarVersions(url string) (versions map[string]Package, err error)
 	versions = map[string]Package{}
 	for _, archive := range archives {
 		filename := path.Base(archive.ZipURL)
-		if !strings.Contains(filename, ".tar.gz") ||
-			(strings.Contains(filename, "enterprise") && !strings.Contains(filename, "standalone")) ||
-			strings.Contains(filename, "cluster") ||
-			strings.Contains(filename, "war") {
+		if !strings.Contains(filename, ".tar.gz") {
 			continue
 		}
 		majmin := archive.Version.MajorMinor()


### PR DESCRIPTION
Update build script for use with JIRA Software edition.

As we discussed you may want to pull this into its own branch. The Oracle JRE was indeed required instead of the OpenJDK JRE.
